### PR TITLE
config: Use pathlib for home instead of looking at $HOME

### DIFF
--- a/mesonwrap/tools/environment.py
+++ b/mesonwrap/tools/environment.py
@@ -1,6 +1,5 @@
+import pathlib
 import configparser
-import os
-import os.path
 
 import github as _github
 
@@ -8,8 +7,7 @@ import github as _github
 class Config:
 
     def __init__(self):
-        configpath = os.path.join(
-            os.getenv('HOME'), '.config', 'mesonwrap.ini')
+        configpath = pathlib.Path.home() / '.config' / 'mesonwrap.ini'
         self._config = configparser.ConfigParser()
         self._config.read(configpath)
 


### PR DESCRIPTION
$HOME is not set on Windows, so use the cross-platform way of getting
the homedir.

This is the only change needed to get mesonwrap working on Windows.